### PR TITLE
Refactor: Custom Image 수정

### DIFF
--- a/src/components/mdx/Image.tsx
+++ b/src/components/mdx/Image.tsx
@@ -8,19 +8,21 @@ interface ImageProps {
 export const MdxImage = ({ src, alt }: ImageProps) => {
     //블로그에 올라가는 이미지는 전부 원격 이미지가 되기 때문에 사이즈를 사전에 알 수가 없음 그래서 img태그 활용
     return (
-        <div>
+        <figure>
             <picture>
+                <source srcSet={src} type="image/webp" />
                 <img
                     src={src}
                     alt={alt}
+                    loading="lazy"
                     className="mx-auto mb-0 mt-8 rounded-md"
                 />
             </picture>
             {alt !== "" && (
-                <span className="w-full block mb-8 mt-2 text-center text-sm text-gray-500 dark:text-gray-400">
+                <figcaption className="w-full block mb-8 mt-2 text-center text-sm text-gray-500 dark:text-gray-400">
                     {alt}
-                </span>
+                </figcaption>
             )}
-        </div>
+        </figure>
     );
 };


### PR DESCRIPTION
- Next/Image를 사용할까 했지만 Remote Image의 동적 사이즈를 사용하고 싶어 img태그를 계속 사용하기로
- lazyloading 추가
- Next/Image랑 비교했을 때 성능 벤치마크 결과가 크게 차이 없었고 오히려 좀더 나은 성능을 보일 때도 있었음